### PR TITLE
Add drive-by committers to event text

### DIFF
--- a/events/weekly-overall.md
+++ b/events/weekly-overall.md
@@ -1,7 +1,7 @@
 
 During the 7-day period starting on :nice_date:, the code that was
-impacted by this vulnerability had :commits: commits by
-:num_devs: different developers.
+impacted by this vulnerability had :commits: commit(s) by
+:num_devs: different developer(s), including :num_drive_bys: drive-by committer(s).
 
 Those changes involved :insertions: line(s) inserted
 and :deletions: line(s) deleted, impacting a total of


### PR DESCRIPTION
See https://github.com/VulnerabilityHistoryProject/vulnerability-history/issues/415 and https://github.com/VulnerabilityHistoryProject/vulnerability-history/pull/707 on vulnerability-history.